### PR TITLE
Fix typo in Shotgun surgery

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is a curated list for when naming things is done right.
 - [Adapter](https://en.wikipedia.org/wiki/Adapter_pattern) - Allows classes with incompatible interfaces to work together by wrapping its own interface around that of an already existing class.
 - [Facade](https://en.wikipedia.org/wiki/Facade_pattern) - Analogous to a facade in architecture, a facade is an object that serves as a front-facing interface masking more complex underlying structure.
 - [Promise](https://en.wikipedia.org/wiki/Futures_and_promises) - A representation of a result that is available in the future, unless there are errors. Like in reality, promises are broken sometimes.
-- [Shotgun surgery](https://en.wikipedia.org/wiki/Shotgun_surgery) - A programming anitpattern where in a single change you wildly add code everywhere in your codebase.
+- [Shotgun surgery](https://en.wikipedia.org/wiki/Shotgun_surgery) - A programming antipattern where in a single change you wildly add code everywhere in your codebase.
 
 ## Functions
 


### PR DESCRIPTION
"A programming _anitpattern_..." --> antipattern